### PR TITLE
Move Jekyll to dev-dependency

### DIFF
--- a/jekyll-html-pipeline.gemspec
+++ b/jekyll-html-pipeline.gemspec
@@ -13,10 +13,10 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "jekyll",    "~> 2.1"
   spec.add_dependency 'html-pipeline', "~> 1.0"
 
   spec.add_development_dependency "bundler", "~> 1.4"
+  spec.add_development_dependency "jekyll",    "~> 2.0"
   spec.add_development_dependency "rake"
   spec.add_development_dependency 'minitest', "~> 5.0"
   spec.add_development_dependency 'github-markdown', "~> 0.6.3"


### PR DESCRIPTION
This avoids conflicts with the github-pages gem.
