### PR TITLE
Update dependencies for Jekyll 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
 language: ruby
 rvm:
-  - 1.9.3
   - 2.0.0

--- a/jekyll-html-pipeline.gemspec
+++ b/jekyll-html-pipeline.gemspec
@@ -15,8 +15,6 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "jekyll", ">= 2.0"
   spec.add_dependency 'html-pipeline', ">= 1.0"
-  spec.add_dependency 'rinku', "~> 1.7" # Required for autolink filter
-  spec.add_dependency 'gemoji', "~> 2.0"
 
   spec.add_development_dependency "bundler", "~> 1.4"
   spec.add_development_dependency "rake"

--- a/jekyll-html-pipeline.gemspec
+++ b/jekyll-html-pipeline.gemspec
@@ -14,12 +14,14 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "jekyll", ">= 2.0"
-  spec.add_dependency 'html-pipeline', "~> 1.0"
+  spec.add_dependency 'html-pipeline', ">= 1.0"
+  spec.add_dependency 'rinku', "~> 1.7" # Required for autolink filter
+  spec.add_dependency 'gemoji', "~> 2.0"
 
   spec.add_development_dependency "bundler", "~> 1.4"
   spec.add_development_dependency "rake"
   spec.add_development_dependency 'minitest', "~> 5.0"
   spec.add_development_dependency 'github-markdown', "~> 0.6.3"
   spec.add_development_dependency 'sanitize', "~> 2.0.6"
-  spec.add_development_dependency 'gemoji', "~> 1.5.0"
+
 end

--- a/jekyll-html-pipeline.gemspec
+++ b/jekyll-html-pipeline.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest', "~> 5.0"
   spec.add_development_dependency 'github-markdown', "~> 0.6.3"
   spec.add_development_dependency 'sanitize', "~> 2.0.6"
-
+  spec.add_development_dependency 'gemoji', "~> 2.0"
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,7 +4,6 @@ require "jekyll"
 require "liquid"
 
 require 'minitest/autorun'
-require 'html/pipeline'
 
 require "jekyll-html-pipeline"
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,6 +4,7 @@ require "jekyll"
 require "liquid"
 
 require 'minitest/autorun'
+require 'html/pipeline'
 
 require "jekyll-html-pipeline"
 


### PR DESCRIPTION
Because all the other HTML Pipeline-based gems require HTML PIpeline >= 2.

I'm getting one failure, that I'm not sure how to fix:

```
  1) Failure:
HTMLPipelineTest#test_fail_when_a_library_dependency_is_not_met [/Users/benbalter/projects/jekyll-html-pipeline/test/test_jekyll_html_pipeline.rb:30]:
LoadError expected but nothing was raised.
```