### PR TITLE
Allow Array of Symbols in Context

### DIFF
--- a/lib/jekyll-html-pipeline.rb
+++ b/lib/jekyll-html-pipeline.rb
@@ -25,6 +25,7 @@ module Jekyll
                     end
           new_value = case value
                       when Hash then symbolize_keys(value)
+                      when Array then value.map &:to_sym
                       else value
                       end
           result[new_key] = new_value

--- a/test/test_jekyll_html_pipeline.rb
+++ b/test/test_jekyll_html_pipeline.rb
@@ -5,7 +5,12 @@ class HTMLPipelineTest < Converter::HTMLPipelineTestCase
     @config = {
       'html_pipeline' => {
         'filters' => ['markdownfilter', 'sanitizationfilter', 'emojifilter', 'mentionfilter'],
-        'context' => { 'asset_root' => 'http://foo.com/icons', 'base_url' => 'https://github.com/'}},
+        'context' => {
+          'asset_root' => 'http://foo.com/icons',
+          'base_url' => 'https://github.com/',
+          'commonmarker_extensions' => ['table', 'strikethrough', 'tagfilter', 'autolink']
+        }
+      },
       'markdown' => 'HTMLPipeline'
     }
     @markdown = Jekyll::Converters::Markdown.new @config


### PR DESCRIPTION
The Markdown filter allows you to specify the extensions by passing in an array of symbols: https://github.com/jch/html-pipeline/blob/4e997bfa7975d917c445bd99cd1949a108604423/lib/html/pipeline/markdown_filter.rb#L13-L14

In Jekyll if you pass an array of strings in the config you will get the following error:
> TypeError: extension names should be Symbols; got a String

This PR adds the ability to convert array of strings to an array of symbols.